### PR TITLE
Add grammar injection for missing colors and godot4 theme colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,36 @@
   "contributes": {
     "themes": [
       {
+        "label": "Godot 4",
+        "uiTheme": "vs-dark",
+        "path": "./themes/Godot-4-color-theme.json"
+      },
+      {
         "label": "Godot",
         "uiTheme": "vs-dark",
         "path": "./themes/Godot-color-theme.json"
+      }
+    ],
+    "grammars": [
+      {
+        "path": "./syntaxes/gdscript.tmLanguage.json",
+        "scopeName": "double-comment.injection",
+        "injectTo": ["source.gdscript"]
+      },
+      {
+        "path": "./syntaxes/comment.keywords.json",
+        "scopeName": "comment-keywords.injection",
+        "injectTo": ["source.gdscript"]
+      },
+      {
+        "path": "./syntaxes/extra.keywords.json",
+        "scopeName": "extra-keywords.injection",
+        "injectTo": ["source.gdscript"]
+      },
+      {
+        "path": "./syntaxes/global.keywords.json",
+        "scopeName": "global-keywords.injection",
+        "injectTo": ["source.gdscript"]
       }
     ]
   }

--- a/syntaxes/comment.keywords.json
+++ b/syntaxes/comment.keywords.json
@@ -1,0 +1,23 @@
+{
+	"injectionSelector": "L:comment.line",
+	"scopeName": "comment-keywords.injection",
+	"patterns": [
+	  {"include": "#warning_keywords" },
+	  {"include": "#critical_keywords" },
+	  {"include": "#notice_keywords" }
+	],
+	"repository": {
+		"warning_keywords": {
+			"name": "comment.keywords.warnings",
+			"match": "BUG|DEPRECATED|FIXME|HACK|TASK|TBD|TODO|WARNING"
+		},
+		"critical_keywords": {
+			"name": "comment.keywords.critical",
+			"match": "ALERT|ATTENTION|CAUTION|CRITICAL|DANGER|SECURITY"
+		},
+		"notice_keywords": {
+			"name": "comment.keywords.notices",
+			"match": "INFO|NOTE|NOTICE|TEST|TESTING"
+		}
+	}
+  }

--- a/syntaxes/extra.keywords.json
+++ b/syntaxes/extra.keywords.json
@@ -1,0 +1,18 @@
+{
+	"injectionSelector": "L:source.gdscript -comment.line -string.quoted.gdscript",
+	"scopeName": "extra-keywords.injection",
+	"patterns": [
+		{"include": "#constant_fix" },
+		{"include": "#void_fix" }
+	],
+	"repository": {
+		"constant_fix": {
+			"match": "\\b(?:true|false|null|PI)\\b",
+			"name": "constant.language.words.gdscript"
+		},
+		"void_fix": {
+			"match": "\\b(?:void)\\b",
+			"name": "meta.void"
+		}
+	}
+  }

--- a/syntaxes/gdscript.tmLanguage.json
+++ b/syntaxes/gdscript.tmLanguage.json
@@ -4,7 +4,8 @@
 	"patterns": [
 	  {"include": "#comment" },
 	  {"include": "#comment_double" },
-	  {"include": "#class_name" }
+	  {"include": "#class_name" },
+	  {"include": "#global_keywords" }
 	],
 	"repository": {
 		"comment": {
@@ -24,6 +25,10 @@
 				"1": { "name": "def.entity.name.type.class.gdscript" },
 				"2": { "name": "class.other.gdscript" }
 			}
+		},
+		"global_keywords": {
+			"match": "\\b(?:preload)\\b",
+			"name": "meta.global-method"
 		}
 	}
   }

--- a/syntaxes/gdscript.tmLanguage.json
+++ b/syntaxes/gdscript.tmLanguage.json
@@ -1,0 +1,29 @@
+{
+	"injectionSelector": "L:source.gdscript",
+	"scopeName": "double-comment.injection",
+	"patterns": [
+	  {"include": "#comment" },
+	  {"include": "#comment_double" },
+	  {"include": "#class_name" }
+	],
+	"repository": {
+		"comment": {
+			"begin": "#(?!#)",
+			"end": "$",
+			"name": "comment.line.number-sign.gdscript",
+			"beginCaptures": { "1": { "name": "punctuation.definition.comment.number-sign.gdscript" } }
+		},
+		"comment_double": {
+			"name": "comment.line.double-number-sign.gdscript",
+			"begin": "##",
+			"end": "$"
+		},
+		"class_name": {
+			"match": "(?<=class_name)\\s+([a-zA-Z_]\\w*(\\.([a-zA-Z_]\\w*))?)",
+			"captures": {
+				"1": { "name": "def.entity.name.type.class.gdscript" },
+				"2": { "name": "class.other.gdscript" }
+			}
+		}
+	}
+  }

--- a/syntaxes/global.keywords.json
+++ b/syntaxes/global.keywords.json
@@ -6,7 +6,7 @@
 	],
 	"repository": {
 		"global_fix": {
-			"match": "\\b(?:print|printt|print_rich|print_err)\\b",
+			"match": "\\b(?:print|printt|print_rich|printerr)\\b",
 			"name": "meta.function-global.gdscript"
 		}
 	}

--- a/syntaxes/global.keywords.json
+++ b/syntaxes/global.keywords.json
@@ -1,0 +1,13 @@
+{
+	"injectionSelector": "L:meta.function-call",
+	"scopeName": "global-keywords.injection",
+	"patterns": [
+		{"include": "#global_fix" }
+	],
+	"repository": {
+		"global_fix": {
+			"match": "\\b(?:print|printt|print_rich|print_err)\\b",
+			"name": "meta.function-global.gdscript"
+		}
+	}
+  }

--- a/themes/Godot-4-color-theme.json
+++ b/themes/Godot-4-color-theme.json
@@ -29,7 +29,7 @@
 		// Debugging colors
 		"statusBar.debuggingBackground": "#364359",
 		// Other colors
-		"editor.background": "#1d2229",
+		"editor.background": "#252b34",
 		"editor.foreground": "#cdcfd2",
 		"sideBarTitle.foreground": "#bbbbbb",
 		"editor.lineHighlightBackground": "#ffffff12",
@@ -64,7 +64,7 @@
 			}
 		},
 		{
-			"name": "Variables",
+			"name": "Variables, Text Color, Godot-Text Color",
 			"scope": [
 				"variable",
 				"meta.function-call.arguments",
@@ -77,7 +77,7 @@
 			}
 		},
 		{
-			"name": "Properties",
+			"name": "Properties, Godot-Member Variable Color",
 			"scope": [
 				"variable.other.property",
 				"variable.other.object.property"
@@ -87,7 +87,7 @@
 			}
 		},
 		{
-			"name": "Invalid",
+			"name": "Invalid, Godot-Breakpoint Color",
 			"scope": [
 				"invalid",
 				"invalid.illegal"
@@ -97,7 +97,7 @@
 			}
 		},
 		{
-			"name": "Keyword, Storage",
+			"name": "Keyword, Storage, Godot-Keywords Color",
 			"scope": [
 				"keyword",
 				"keyword.control",
@@ -114,7 +114,7 @@
 			}
 		},
 		{
-			"name": "Number",
+			"name": "Godot-Number Color",
 			"scope": [
 				"constant.numeric"
 			],
@@ -123,7 +123,7 @@
 			}
 		},
 		{
-			"name": "Operator, Misc",
+			"name": "Operator, Misc, Godot-Symbol Color",
 			"scope": [
 				"constant.other.color",
 				"punctuation",
@@ -143,14 +143,13 @@
 			}
 		},
 		{
-			"name": "Functions",
+			"name": "Functions, Member Color, Godot-Function Color",
 			"scope": [
 				"entity.name.function",
 				"meta.function-call",
 				"variable.function",
 				"support.function",
 				"keyword.other.special-method",
-				"support.function",
 				"support.function.any-method"
 			],
 			"settings": {
@@ -158,7 +157,7 @@
 			}
 		},
 		{
-			"name": "String, Symbols, Markup Heading",
+			"name": "String, Symbols, Markup Heading, Godot-String Color",
 			"scope": [
 				"string",
 				"punctuation.definition.string",
@@ -178,7 +177,7 @@
 			}
 		},
 		{
-			"name": "Class",
+			"name": "Class, Godot-Base Type Color",
 			"scope": [
 				"entity.name",
 				"entity.other.inherited-class",
@@ -194,7 +193,7 @@
 			}
 		},
 		{
-			"name": "Builtin Classes, Engine Type Color",
+			"name": "Builtin Classes, Godot-Engine Type Color",
 			"scope": [
 				"entity.name.class.builtin",
 				"support.type",
@@ -244,6 +243,8 @@
 				"foreground": "#82AAFF"
 			}
 		},
+
+
 		{
 			"name": "Comment keywords WARNING, TOOD/FIXME",
 			"scope": [
@@ -272,16 +273,16 @@
 			}
 		},
 		{
-			"name": "Keywords, Control Flow Keyword Color",
+			"name": "Keywords, Godot-Control Flow Keyword Color",
 			"scope": [
-				"keyword.control",
+				"keyword.control.flow",
 			],
 			"settings": {
 				"foreground": "#ff8ccc"
 			}
 		},
 		{
-			"name": "Function definition",
+			"name": "Godot-Function Definition Color",
 			"scope": [
 				"entity.name.function.gdscript"
 			],
@@ -290,13 +291,45 @@
 			}
 		},
 		{
-			"name": "Annotation Color,  @ keyword",
+			"name": "Godot-Annotation Color,  @ keyword",
 			"scope": [
 				"entity.name.function.decorator.gdscript",
 			],
 			"settings": {
 				"foreground": "#ffb373"
 			}
+		},
+		{
+			"name": "Loose constant, enum classname, class constants",
+			"scope": [
+				"constant.language.gdscript",
+			],
+			"settings": {
+				"foreground": "#e7e7e9"
+			}
+		},
+		{
+			"name": "Godot-Global Function Color",
+			"scope": [
+				"meta.global-method",
+				"meta.keyword.language.gdscript",
+				"meta.function-global.gdscript"
+			],
+			"settings": {
+				"foreground": "#a3a3f5"
+			}
+		},
+		{
+			"name": "Godot-Global Function Color",
+			"scope": [
+				"meta.literal.nodepath.gdscript constant.character.escape.gdscript",
+				"meta.literal.nodepath.gdscript keyword.control.flow.gdscript",
+				"extra.keyword.language.gdscript"
+			],
+			"settings": {
+				"foreground": "#63c259"
+			}
 		}
+		
 	]
 }

--- a/themes/Godot-4-color-theme.json
+++ b/themes/Godot-4-color-theme.json
@@ -329,7 +329,15 @@
 			"settings": {
 				"foreground": "#63c259"
 			}
+		},
+		{
+			"name": "Double comment color",
+			"scope": [
+				"comment.line.double-number-sign.gdscript"
+			],
+			"settings": {
+				"foreground": "#7e94aa"
+			}
 		}
-		
 	]
 }

--- a/themes/Godot-color-theme.json
+++ b/themes/Godot-color-theme.json
@@ -297,6 +297,15 @@
 			"settings": {
 				"foreground": "#ffb373"
 			}
+		},
+		{
+			"name": "Double comment color",
+			"scope": [
+				"comment.line.double-number-sign.gdscript"
+			],
+			"settings": {
+				"foreground": "#7e94aa"
+			}
 		}
 	]
 }


### PR DESCRIPTION
I added a few grammar injections to fix some of the missing colors.
I noticed that the original theme had a slight darker background (maybe based godot3 theme?)
So I made a "Godot 4" theme to apply most of the changes.
I only added the new grammar injection colors to the original theme. Double comment colors, TODO: keywords, etc.

**Here is the final result.**
Godot 4 Theme(LEFT) | Godot 4 engine (RIGHT)
<p float="left">
<img src="https://github.com/ryanabx/godot-vscode-theme/assets/3084189/867aac4a-18c4-489b-be2f-c40afe27c4b4" width=49%>
<img src="https://github.com/ryanabx/godot-vscode-theme/assets/3084189/144d5b65-7caf-41e2-979a-171092aaa764" width=49%>
</p>
godot-vscode doesn't have a semantic token for global functions, so I hard-coded the common ones like 'print', 'printt', 'printerr'.
More can be added later.

---
I left constants to be white. vscode takes enums as constants and leaving it as the godot blue makes a very bad visual representation when using enums with two blue colors.
So I also left the constants color for a slight brighter white so things like Vector3.ONE don't feel like they are missing.

---

There are still a few things that can't be done because of missing semantic tokens on godot plugin. For example, Godot uses a slight different shade of green for user created classes. But that might be nitpicking. I think its already fairly accurate as it is now.